### PR TITLE
Fix benchmark workflow Python version

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
+          - '3.8'
 
     steps:
       - name: Checkout
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
+          - '3.8'
 
       # so we don't have jobs trying to push to git at the same time
       max-parallel: 1


### PR DESCRIPTION
## Summary
- update the benchmark workflow matrix from Python 3.7 to Python 3.8
- keep benchmark jobs aligned with the repository's supported Python versions

## Validation
- git diff --check

Adding the run-benchmarks label should trigger the benchmark workflow.